### PR TITLE
changed all reference to 'post' or 'posts' to 'finstagram_post(s)'

### DIFF
--- a/db/migrate/0_create_base_tables.rb
+++ b/db/migrate/0_create_base_tables.rb
@@ -9,7 +9,7 @@ class CreateBaseTables < ActiveRecord::Migration
       t.timestamps
     end
 
-    create_table :posts do |t|
+    create_table :finstagram_posts do |t|
       t.references :user
       t.string :photo_url
       t.timestamps
@@ -17,14 +17,14 @@ class CreateBaseTables < ActiveRecord::Migration
 
     create_table :comments do |t|
       t.references :user
-      t.references :post
+      t.references :finstagram_post
       t.text :text
       t.timestamps
     end
 
     create_table :likes do |t|
       t.references :user
-      t.references :post
+      t.references :finstagram_post
       t.timestamps
     end
 

--- a/public/stylesheets/lib.css
+++ b/public/stylesheets/lib.css
@@ -40,12 +40,12 @@ main {
   margin: 0 auto;
 }
 
-.new-post {
+.new-finstagram-post {
   text-align: center;
   margin-bottom: 2em;
 }
 
-.new-post > .button {
+.new-finstagram-post > .button {
   display: inline-block;
   padding: 1em;
   width: 100%;
@@ -60,7 +60,7 @@ main {
   display: inline-block;
 }
 
-.post > * {
+.finstagram-post > * {
   margin-bottom: 1em;
 }
 


### PR DESCRIPTION
Due to a change to the curriculum, any reference to 'post' is changed to 'finstagram_post'.

This is so to avoid confusing between the 'post' http method and finstagram 'posts'