### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 
 gem 'rake'
 gem 'activesupport'
+gem 'activerecord', '~> 4.2.0'
 
 gem 'sinatra'
 gem 'sinatra-contrib'


### PR DESCRIPTION
We were getting an error : DEPRECATION WARNING: Setting `ActiveRecord::Base.configurations` with `[]=` is deprecated. Use `ActiveRecord::Base.configurations=` directly to set the configurations instead. (called from block in <top (required)> at /home/cabox/workspace/finstagram/config/database.rb:7)
This fixed the dependencies.