### PR TITLE
persist path to workspace ruby-2.6.7 on new bash terminal

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -6,3 +6,4 @@ COPY --chown=gitpod:gitpod .ruby-version /tmp
 RUN echo "rvm_gems_path=/home/gitpod/.rvm" > ~/.rvmrc
 RUN bash -lc "rvm install ruby-$(cat /tmp/.ruby-version) && rvm use ruby-$(cat /tmp/.ruby-version) --default"
 RUN echo "rvm_gems_path=/workspace/.rvm" > ~/.rvmrc
+RUN echo '{ rvm use $(rvm current); } >/dev/null 2>&1' >> "$HOME/.bashrc.d/70-ruby"


### PR DESCRIPTION
## Change Summary

On a Gitpod workspace startup the initial bash terminal has a correct set $PATH to `/workspace/.rvm/ruby-2.6.7/bin` but Gitpod uses a standard $PATH when a new terminal is opened that's missing the specified ruby version path.

## Implementation Details

- Added a Dockerfile RUN instruction to force the rvm usage of the correct ruby version

## Estimation

Estimated: 0.5 hr
Actual: 0.5 hr