### PR TITLE
fix rack secret requirement to use 32 byte long string

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -19,7 +19,7 @@ configure do
   set :server, :puma
 
   enable :sessions
-  set :session_secret, ENV['SESSION_KEY'] || 'lighthouselabssecret'
+  set :session_secret, ENV['SESSION_KEY'] || 'f06bbeb1f88cce86fb7bf89b6c2d8aa88e2ebcd9c7a8bce0e27d3e6b4c8e6dc3'
 
   set :views, File.join(Sinatra::Application.root, "app", "views")
 end


### PR DESCRIPTION
## Change Summary

Rack updated its rack-protection dependency to 3.0.1 which now requires the secret to be at least 32 bytes long. Updated the previous `'lighthouselabssecret'` secret to meet this requirement.

## Implementation Details

- Updated `config/environment.rb` secret to conform to 32 byte long requirement