### PR TITLE
lock 'gitpod/workspace-full' docker image to '2023-02-27-14-39-56' to…

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-full
+FROM gitpod/workspace-full:2023-02-27-14-39-56
 USER gitpod
 
 # Install the Ruby version specified in '.ruby-version'


### PR DESCRIPTION
## Change Summary
Gitpod's latest 'workspace/full' Docker image now installs Ubuntu version 22.x LTS and the accompanying OpenSSL version 3.x. The issue is that this project makes use of Ruby version 2.6.7 which is incompatible with the previously described Ubuntu environment. 

## Implementation Details
Lock Gitpod's Docker image to 'gitpod/workspace-full:2023-02-27-14-39-56', which is the last Gitpod Docker image to incorporate Ubuntu 20.x LTS along with OpenSSL 1.1.x. This environment is compatible with the project's Ruby 2.6.7 versioning and the downstream gem requirements.